### PR TITLE
Adds 2021 iPads 11" and 12.9"

### DIFF
--- a/Sources/UIScreenExtension/UIScreenExtension.swift
+++ b/Sources/UIScreenExtension/UIScreenExtension.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-private extension UIDevice {
+internal extension UIDevice {
     
     // model identifiers can be found at https://www.theiphonewiki.com/wiki/Models
     static let modelIdentifier: String = {
@@ -103,13 +103,15 @@ public extension UIScreen {
             return 10.9
             
         case "iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4": fallthrough // iPad Pro (11 inch)
-        case "iPad8,9", "iPad8,10":                                  // iPad Pro (11 inch, 2nd generation)
+        case "iPad8,9", "iPad8,10":                      fallthrough // iPad Pro (11 inch, 2nd generation)
+        case "iPad13,5":                                             // iPad Pro (11 inch, 3rd generation)
             return 11.0
             
         case "iPad6,7", "iPad6,8":                       fallthrough // iPad Pro (12.9 inch)
         case "iPad7,1", "iPad7,2":                       fallthrough // iPad Pro (12.9 inch, 2nd generation)
         case "iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8": fallthrough // iPad Pro (12.9 inch, 3rd generation)
-        case "iPad8,11", "iPad8,12":                                 // iPad Pro (12.9 inch, 4th generation)
+        case "iPad8,11", "iPad8,12":                     fallthrough // iPad Pro (12.9 inch, 4th generation)
+        case "iPad13,10":                                            // iPad Pro (12.9 inch, 5th generation)
             return 12.9
             
         default:                                                     // unknown model identifier

--- a/UIScreenExtension.xcodeproj/project.pbxproj
+++ b/UIScreenExtension.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		134B309A1F822DC20040885A /* UIScreenExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134B30991F822DC20040885A /* UIScreenExtension.swift */; };
 		139181181F8255A2009C354A /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 139181171F8255A2009C354A /* README.md */; };
 		1391811A1F825CEA009C354A /* UIScreenExtension.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 139181191F825CEA009C354A /* UIScreenExtension.podspec */; };
+		9AA14A7B266B79A300ED55F2 /* SimulatorDeviceInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA14A7A266B79A300ED55F2 /* SimulatorDeviceInfoView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,6 +21,7 @@
 		134B30991F822DC20040885A /* UIScreenExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIScreenExtension.swift; path = Sources/UIScreenExtension/UIScreenExtension.swift; sourceTree = SOURCE_ROOT; };
 		139181171F8255A2009C354A /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		139181191F825CEA009C354A /* UIScreenExtension.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = UIScreenExtension.podspec; sourceTree = "<group>"; };
+		9AA14A7A266B79A300ED55F2 /* SimulatorDeviceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorDeviceInfoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +59,7 @@
 				134B30911F822DA60040885A /* UIScreenExtension.h */,
 				134B30921F822DA60040885A /* Info.plist */,
 				134B30991F822DC20040885A /* UIScreenExtension.swift */,
+				9AA14A7A266B79A300ED55F2 /* SimulatorDeviceInfoView.swift */,
 			);
 			path = UIScreenExtension;
 			sourceTree = "<group>";
@@ -144,6 +147,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				134B309A1F822DC20040885A /* UIScreenExtension.swift in Sources */,
+				9AA14A7B266B79A300ED55F2 /* SimulatorDeviceInfoView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UIScreenExtension.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/UIScreenExtension.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/UIScreenExtension/SimulatorDeviceInfoView.swift
+++ b/UIScreenExtension/SimulatorDeviceInfoView.swift
@@ -1,0 +1,24 @@
+//
+//  SimulatorDeviceInfoView.swift
+//  UIScreenExtension
+//
+//  Created by Tristan Warner-Smith on 05/06/2021.
+//  Copyright © 2021 marchv. All rights reserved.
+//
+
+import SwiftUI
+
+struct SimulatorDeviceInfoView: View {
+
+    @available(iOS 13.0, *)
+    var body: some View {
+        Text("Model identifier: ") + Text("\(UIDevice.modelIdentifier)").bold()
+    }
+}
+
+struct SimulatorDeviceInfoView_Previews: PreviewProvider {
+    @available(iOS 13.0, *)
+    static var previews: some View {
+        SimulatorDeviceInfoView()
+    }
+}


### PR DESCRIPTION
• Also adds SwiftUI visualiser for the active simulator to show the internal model name to make identifying new models quicker
• Changes modelIdentifier to be internal so it could be used in SimulatorDeviceInfoView

If you're not ready / comfortable with the SwiftUI code I can nix it 👍 