### PR TITLE
Adds missing variants of the 2021 iPads

### DIFF
--- a/Sources/UIScreenExtension/UIScreenExtension.swift
+++ b/Sources/UIScreenExtension/UIScreenExtension.swift
@@ -104,14 +104,14 @@ public extension UIScreen {
             
         case "iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4": fallthrough // iPad Pro (11 inch)
         case "iPad8,9", "iPad8,10":                      fallthrough // iPad Pro (11 inch, 2nd generation)
-        case "iPad13,5":                                             // iPad Pro (11 inch, 3rd generation)
+        case "iPad13,4", "iPad13,5", "iPad13,6", "iPad13,7":         // iPad Pro (11 inch, 3rd generation)
             return 11.0
             
         case "iPad6,7", "iPad6,8":                       fallthrough // iPad Pro (12.9 inch)
         case "iPad7,1", "iPad7,2":                       fallthrough // iPad Pro (12.9 inch, 2nd generation)
         case "iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8": fallthrough // iPad Pro (12.9 inch, 3rd generation)
         case "iPad8,11", "iPad8,12":                     fallthrough // iPad Pro (12.9 inch, 4th generation)
-        case "iPad13,10":                                            // iPad Pro (12.9 inch, 5th generation)
+        case "iPad13,8", "iPad13,9", "iPad13,10", "iPad13,11":       // iPad Pro (12.9 inch, 5th generation)
             return 12.9
             
         default:                                                     // unknown model identifier


### PR DESCRIPTION
My apologies I missed several other variants and only realised when connecting to a real device.
Harvested variants from https://www.theiphonewiki.com/wiki/BORD
Variants 13,4-13,7 are all iPad Pro (11 inch, 3rd generation), variants 13,8-13,11 are all iPad Pro (12.9 inch, 5th generation)