### PR TITLE
Added Spring 2025 models

### DIFF
--- a/Sources/UIScreenExtension/UIScreenExtension.swift
+++ b/Sources/UIScreenExtension/UIScreenExtension.swift
@@ -73,7 +73,8 @@ public extension UIScreen {
         case "iPhone15,2":                                     fallthrough // iPhone 14 Pro
         case "iPhone15,4":                                     fallthrough // iPhone 15
         case "iPhone16,1":                                     fallthrough // iPhone 15 Pro
-        case "iPhone17,3":                                                 // iPhone 16
+        case "iPhone17,3":                                     fallthrough // iPhone 16
+        case "iPhone17,5":                                                 // iPhone 16e
             return 6.1
 
         case "iPhone17,1":                                                 // iPhone 16 Pro
@@ -132,11 +133,14 @@ public extension UIScreen {
         case "iPad13,4", "iPad13,5", "iPad13,6", "iPad13,7":   fallthrough // iPad Pro (11 inch, 3rd generation)
         case "iPad14,3", "iPad14,4":                           fallthrough // iPad Pro (11 inch, 4th generation)
         case "iPad14,8", "iPad14,9":                           fallthrough // iPad Air (11 inch, 6th generation)
-        case "iPad16,3", "iPad16,4":                                       // iPad Pro (11 inch, 7th generation)
+        case "iPad16,3", "iPad16,4":                           fallthrough // iPad Pro (11 inch, 7th generation)
+        case "iPad15,3", "iPad15,4":                           fallthrough // iPad Air (11 inch, 7th generation)
+        case "iPad15,7", "iPad15,8":                                       // iPad 11th generation
             return 11.0
             
         case "iPad14,10", "iPad14,11":                         fallthrough // iPad Air (13 inch, 6th generation)
-        case "iPad16,5", "iPad16,6":                                       // iPad Pro (13 inch, 7th generation)
+        case "iPad16,5", "iPad16,6":                           fallthrough // iPad Pro (13 inch, 7th generation)
+        case "iPad15,5", "iPad15,6":                                       // iPad Air (13 inch, 7th generation)
             return 13.0
 
         case "iPad6,7", "iPad6,8":                             fallthrough // iPad Pro (12.9 inch)


### PR DESCRIPTION
In this PR added: iPhone 16e,iPad Air 11 inch (7th gen), iPad Air 13 inch (7th gen), iPad (11th gen)